### PR TITLE
Fix libcurand tests.

### DIFF
--- a/recipes/libcurand/meta.yaml
+++ b/recipes/libcurand/meta.yaml
@@ -27,6 +27,14 @@ build:
   number: 0
   skip: true  # [osx]
 
+test:
+  commands:
+    - test -L $PREFIX/lib/libcurand.so.{{ version.split(".")[0] }}                            # [linux]
+    - test -L $PREFIX/lib/libcurand.so.{{ version }}                                          # [linux]
+    - test -L $PREFIX/targets/{{ target_name }}/lib/libcurand.so.{{ version.split(".")[0] }}  # [linux]
+    - test -f $PREFIX/targets/{{ target_name }}/lib/libcurand.so.{{ version }}                # [linux]
+    - if not exist %LIBRARY_BIN%\curand64_{{ version.split(".")[0] }}.dll exit 1              # [win]
+
 outputs:
   - name: libcurand
     files:
@@ -47,13 +55,7 @@ outputs:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
       run_constrained:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
-    test:
-      commands:
-        - test -L $PREFIX/lib/libcurand.so.{{ version }}                                          # [linux]
-        - test -L $PREFIX/lib/libcurand.so.{{ version.split(".")[0] }}                            # [linux]
-        - test -f $PREFIX/targets/{{ target_name }}/lib/libcurand.so.{{ version }}                # [linux]
-        - test -L $PREFIX/targets/{{ target_name }}/lib/libcurand.so.{{ version.split(".")[0] }}  # [linux]
-        - if not exist %LIBRARY_BIN%\curand64_{{ version.split(".")[0] }}.dll exit 1              # [win]
+    # Tests are defined at the top level, due to package/output name conflicts.
     about:
       home: https://developer.nvidia.com/curand
       license: LicenseRef-NVIDIA-End-User-License-Agreement


### PR DESCRIPTION
Fixed libcurand tests. See https://github.com/conda-forge/libcublas-feedstock/pull/10/ for context.